### PR TITLE
Fix: compare autoscaled space instead of total filesystem size

### DIFF
--- a/bin/ebs-autoscale
+++ b/bin/ebs-autoscale
@@ -100,8 +100,8 @@ add_space () {
     return 0
   fi
 
-  local curr_size=$(df -BG ${MOUNTPOINT} | grep ${MOUNTPOINT} | awk '{print $2} ' | cut -d'G' -f1)
-  if [ "${curr_size}" -lt "$MAX_LOGICAL_VOLUME_SIZE" ]; then
+  local curr_autoscaled_size=$(cat /var/run/ebs_autoscale_created_size)
+  if [ "${curr_autoscaled_size}" -lt "$MAX_LOGICAL_VOLUME_SIZE" ]; then
     local vol_size=$(calc_new_size ${num_devices})
     loginfo "Extending logical volume ${MOUNTPOINT} by ${vol_size}GB"
 
@@ -109,6 +109,8 @@ add_space () {
 
     exit_status=$?
     if [ $exit_status -eq 0 ]; then
+      # Update the total autoscaled size
+      echo $((total_autoscaled_size + vol_size)) > /var/run/ebs_autoscale_created_size
       if [ "${FILE_SYSTEM}" = "btrfs" ]; then
         loginfo "Adding device ${DEVICE} to logical volume ${MOUNTPOINT}"
         btrfs device add ${DEVICE} ${MOUNTPOINT}


### PR DESCRIPTION
The autoscale was being disabled on instances with large NVMe drives (e.g. i4g.4xlarge with 3.5TB) because it was comparing the total filesystem size against MAX_LOGICAL_VOLUME_SIZE. This change modifies the check to only consider the autoscaled EBS volume space, allowing the autoscale to work properly regardless of the initial storage size.
